### PR TITLE
안녕하세요 유튜브 강의 잘듣고 있습니다. 자스스톤 게임에서 게임끝난후 초기화와 영웅카드및  필드카드 동시선택  에러가 있어서 코드 수정좀 하였습니다.

### DIFF
--- a/자스스톤.js
+++ b/자스스톤.js
@@ -42,18 +42,16 @@ function 덱에서필드로(데이터, 내턴) {
 
 function 필드다시그리기(객체) {
   객체.필드.innerHTML = '';
-  객체.필드data.forEach(function (data) {
+  객체.필드data.forEach(function(data) {
     카드돔연결(data, 객체.필드);
   });
 }
-
 function 덱다시그리기(객체) {
   객체.덱.innerHTML = '';
-  객체.덱data.forEach(function (data) {
+  객체.덱data.forEach(function(data) {
     카드돔연결(data, 객체.덱);
   });
 }
-
 function 영웅다시그리기(객체) {
   객체.영웅.innerHTML = '';
   카드돔연결(객체.영웅data, 객체.영웅, true);
@@ -79,7 +77,7 @@ function 턴액션수행(카드, 데이터, 내턴) {
     데이터.hp = 데이터.hp - 아군.선택카드data.att;
     if (데이터.hp <= 0) { // 카드가 죽었을 때
       var 인덱스 = 적군.필드data.indexOf(데이터);
-      if (인덱스 > -1) { // 쫄병이 죽었을 때
+      if (인덱스 > -1 ) { // 쫄병이 죽었을 때
         적군.필드data.splice(인덱스, 1);
       } else { // 영웅이 죽었을 때
         alert('승리하셨습니다!');
@@ -122,31 +120,27 @@ function 카드돔연결(데이터, 돔, 영웅) {
     이름.textContent = '영웅';
     카드.appendChild(이름)
   }
-  카드.addEventListener('click', function () {
+  카드.addEventListener('click', function() {
     턴액션수행(카드, 데이터, 턴);
   });
   돔.appendChild(카드);
 }
-
 function 상대덱생성(개수) {
   for (var i = 0; i < 개수; i++) {
     상대.덱data.push(카드공장());
   }
   덱다시그리기(상대);
 }
-
 function 내덱생성(개수) {
   for (var i = 0; i < 개수; i++) {
     나.덱data.push(카드공장(false, true));
   }
   덱다시그리기(나);
 }
-
 function 내영웅생성() {
   나.영웅data = 카드공장(true, true);
   카드돔연결(나.영웅data, 나.영웅, true);
 }
-
 function 상대영웅생성() {
   상대.영웅data = 카드공장(true);
   카드돔연결(상대.영웅data, 상대.영웅, true);
@@ -167,7 +161,6 @@ function Card(영웅, 내카드) {
     this.mine = true;
   }
 }
-
 function 카드공장(영웅, 내카드) {
   return new Card(영웅, 내카드);
 }
@@ -188,7 +181,7 @@ function 초기세팅() {
   화면다시그리기(false); // 내화면
 }
 
-턴버튼.addEventListener('click', function () {
+턴버튼.addEventListener('click', function() {
   var 객체 = 턴 ? 나 : 상대;
   document.getElementById('rival').classList.toggle('turn');
   document.getElementById('my').classList.toggle('turn');

--- a/자스스톤.js
+++ b/자스스톤.js
@@ -42,16 +42,18 @@ function 덱에서필드로(데이터, 내턴) {
 
 function 필드다시그리기(객체) {
   객체.필드.innerHTML = '';
-  객체.필드data.forEach(function(data) {
+  객체.필드data.forEach(function (data) {
     카드돔연결(data, 객체.필드);
   });
 }
+
 function 덱다시그리기(객체) {
   객체.덱.innerHTML = '';
-  객체.덱data.forEach(function(data) {
+  객체.덱data.forEach(function (data) {
     카드돔연결(data, 객체.덱);
   });
 }
+
 function 영웅다시그리기(객체) {
   객체.영웅.innerHTML = '';
   카드돔연결(객체.영웅data, 객체.영웅, true);
@@ -77,7 +79,7 @@ function 턴액션수행(카드, 데이터, 내턴) {
     데이터.hp = 데이터.hp - 아군.선택카드data.att;
     if (데이터.hp <= 0) { // 카드가 죽었을 때
       var 인덱스 = 적군.필드data.indexOf(데이터);
-      if (인덱스 > -1 ) { // 쫄병이 죽었을 때
+      if (인덱스 > -1) { // 쫄병이 죽었을 때
         적군.필드data.splice(인덱스, 1);
       } else { // 영웅이 죽었을 때
         alert('승리하셨습니다!');
@@ -94,7 +96,9 @@ function 턴액션수행(카드, 데이터, 내턴) {
     return;
   }
   if (데이터.field) { // 카드가 필드에 있으면
-    카드.parentNode.querySelectorAll('.card').forEach(function(card) {
+    //  영웅 부모와 필드카드의 부모가 다르기때문에 document에서 모든 .card를 검색한다
+    // 카드.parentNode.querySelectorAll('.card').forEach(function (card) {
+    document.querySelectorAll('.card').forEach(function (card) {
       card.classList.remove('card-selected');
     });
     카드.classList.add('card-selected');
@@ -118,27 +122,31 @@ function 카드돔연결(데이터, 돔, 영웅) {
     이름.textContent = '영웅';
     카드.appendChild(이름)
   }
-  카드.addEventListener('click', function() {
+  카드.addEventListener('click', function () {
     턴액션수행(카드, 데이터, 턴);
   });
   돔.appendChild(카드);
 }
+
 function 상대덱생성(개수) {
   for (var i = 0; i < 개수; i++) {
     상대.덱data.push(카드공장());
   }
   덱다시그리기(상대);
 }
+
 function 내덱생성(개수) {
   for (var i = 0; i < 개수; i++) {
     나.덱data.push(카드공장(false, true));
   }
   덱다시그리기(나);
 }
+
 function 내영웅생성() {
   나.영웅data = 카드공장(true, true);
   카드돔연결(나.영웅data, 나.영웅, true);
 }
+
 function 상대영웅생성() {
   상대.영웅data = 카드공장(true);
   카드돔연결(상대.영웅data, 상대.영웅, true);
@@ -159,11 +167,19 @@ function Card(영웅, 내카드) {
     this.mine = true;
   }
 }
+
 function 카드공장(영웅, 내카드) {
   return new Card(영웅, 내카드);
 }
 
 function 초기세팅() {
+  [상대, 나].forEach(function (item) {
+    item.덱data = [];
+    item.영웅data = [];
+    item.필드data = [];
+    item.선택카드 = [];
+    item.선택카드data = [];
+  });
   상대덱생성(5);
   내덱생성(5);
   내영웅생성();
@@ -172,7 +188,7 @@ function 초기세팅() {
   화면다시그리기(false); // 내화면
 }
 
-턴버튼.addEventListener('click', function() {
+턴버튼.addEventListener('click', function () {
   var 객체 = 턴 ? 나 : 상대;
   document.getElementById('rival').classList.toggle('turn');
   document.getElementById('my').classList.toggle('turn');


### PR DESCRIPTION
깃헙도잘모르고 contribution도 이렇게 하는지 잘모르겠네요 ㅇㅅㅇ;;
 

자스스톤 초기화 및 영웅카드와 필드카드 동시선택 문제 해결
초기세팅 추가코드
[상대, 나].forEach(function (item) {
    item.덱data = [];
    item.영웅data = [];
    item.필드data = [];
    item.선택카드 = [];
    item.선택카드data = [];
  });


턴액션수행 함수 코드 수정
//  영웅 부모와 필드카드의 부모가 다르기때문에 document에서 모든 .card를 검색한다
// 카드.parentNode.querySelectorAll('.card').forEach(function (card) {
document.querySelectorAll('.card').forEach(function (card) {